### PR TITLE
FIX broken scope handling for base_uri (#11)

### DIFF
--- a/lib/jsonapi/record/metal.rb
+++ b/lib/jsonapi/record/metal.rb
@@ -116,7 +116,7 @@ module JSONAPI
 
         # @return [String]
         def collection_path
-          "/#{type}"
+          "#{type}"
         end
 
         # @param id [String]

--- a/spec/jsonapi/record/metal_spec.rb
+++ b/spec/jsonapi/record/metal_spec.rb
@@ -9,8 +9,10 @@ RSpec.describe JSONAPI::Record::Metal do
   let(:post) { Post.new(title: "Post1", body: "Lorem Ipsum") }
   let(:type) { User.type }
   let(:base_uri) { User.base_uri }
+  let(:scoped_base_uri) { UserWithScopedUri.base_uri }
   let(:relationship_name) { "posts" }
   let(:collection_uri) { "#{base_uri}/#{type}" }
+  let(:scoped_collection_uri) { "#{scoped_base_uri}#{type}" }
   let(:individual_uri) { "#{base_uri}/#{type}/#{id}" }
   let(:related_resource_uri) { "#{base_uri}/#{type}/#{id}/#{relationship_name}" }
 
@@ -37,6 +39,10 @@ RSpec.describe JSONAPI::Record::Metal do
   describe ".collection_uri" do
     it "returns collection_uri" do
       expect(User.collection_uri).to eq collection_uri
+    end
+
+    it "returns collection_uri with scope" do
+      expect(UserWithScopedUri.collection_uri).to eq scoped_collection_uri
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ require "support/profile"
 require "support/post"
 require "support/blog_post"
 require "support/user"
+require "support/user_with_scoped_uri"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/support/user_with_scoped_uri.rb
+++ b/spec/support/user_with_scoped_uri.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class UserWithScopedUri < Base
+  type "users"
+
+  base_uri "https://api.example.com/api/v1/"
+
+  attribute :email, Types::String
+
+  relationship_to_many :posts, class_name: "Post"
+  relationship_to_one :profile, class_name: "Profile"
+end


### PR DESCRIPTION
Fixed #11 

Let the user decide if it should be joined. (slash at the end)

https://apidock.com/ruby/URI/join/class
```
URI.join('http://example.com/example', 'test').to_s
# => "http://example.com/test"

URI.join('http://example.com/example/', 'test').to_s
# => "http://example.com/example/test"
```